### PR TITLE
Added template version requirement note

### DIFF
--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -103,6 +103,9 @@ In this task you will:
 
 2.  On the issuing CA, use the Certificate Templates snap-in to create a new custom template or copy an existing template and then edit an existing template (like the User template), for use with NDES.
 
+	>[!NOTE]
+	> The NDES certificate template must be based off a v2 Certificate Template (with Windows 2003 compatibility).
+
     The template must have the following configurations:
 
     -   Specify a friendly **Template display name** for the template.


### PR DESCRIPTION
The v2 template version (Windows 2003 compatibility) requirement is lacking from the document. Using a v3 Template, say copying from a modern PKI/CA User Template, will cause failures.