### PR TITLE
Update device-restrictions-windows-10.md

### DIFF
--- a/intune/device-restrictions-windows-10.md
+++ b/intune/device-restrictions-windows-10.md
@@ -70,7 +70,7 @@ For devices running Windows 10 Mobile: After sign-in fails the number of times y
 	- 	**Prevent reuse of previous passwords** - Specifies the number of previously used passwords that are remembered by the device.
 	- 	**Require password when device returns from idle state (Mobile only)** - Specifies that the user must enter a password to unlock the device (Windows 10 Mobile only).
 	- 	**Simple passwords** – Lets you allow the use of simple passwords like 1111 and 1234. This setting also allows or blocks the use of Windows picture passwords.
-- 	**Encryption** - Enable encryption on targeted devices (Windows 10 Mobile only).
+- 	**Encryption** - Enable encryption on targeted devices.
 
 ## Personalization
 


### PR DESCRIPTION
requested BY CSS escalation engineer Joel Stevens <REDMOND\joelste>in CSS Content Idea Request 69243:Remove Windows 10 Mobile caveat from Password/Encryption section of WIndows 10 Device Restriction Page. As reported on ICM https://icm.ad.msft.net/imp/v3/incidents/details/49214520 the workaround for Home/Pro sku is to use this setting instead. This setting not working on all versions of Windows 10 was an Intune bug that has since been fixed