### PR TITLE
Update actions-for-noncompliance.md

### DIFF
--- a/intune/actions-for-noncompliance.md
+++ b/intune/actions-for-noncompliance.md
@@ -33,7 +33,7 @@ The **actions for non-compliance** allow you to configure a time-ordered sequenc
 
 There are two types of actions:
 
--   **Notify end-users via e-mail**: You can customize your email notification before sending it to the end user. Intune provides customization of the subject, message body, including company logo, contact information and additional recipients.
+-   **Notify end-users via e-mail**: You can customize your email notification before sending it to the end user. Intune provides customization of the subject, message body, including company logo, and contact information.
 
 -   **Mark device non-compliant**: You can determine a schedule in number of days after the device should be marked not compliant. This can be immediately, but you can also give the user a grace period to be compliant with your device compliance policies.
 


### PR DESCRIPTION
You can do customization of the subject, message body, company log, and contact information. However, you can not add additional recipients to your end user email. That should be omitted from the article.

Option to add additional recipients to end user noncompliance email should be omitted from the article.

From CSS Content Idea Request 72798:Change to https://docs.microsoft.com/en-us/intune/actions-for-noncompliance, approved in CSS content triage.