### PR TITLE
Add clarity line for supported devices

### DIFF
--- a/intune/includes/mdm-supported-devices.md
+++ b/intune/includes/mdm-supported-devices.md
@@ -12,6 +12,7 @@
   - Windows 10 (Home, S, Pro, Education, and Enterprise versions)
   - Windows 10 Mobile
   - Devices running Windows 10 IoT Enterprise (x86, x64)
+  - Devices running Windows 10 Enterprise LTSC (Long-Term Servicing Channel)
   - Devices running Windows 10 IoT Mobile Enterprise
   - Windows Holographic & Windows Holographic Enterprise
   - Windows Phone 8.1, Windows 8.1 RT, PCs running Windows 8.1 (Sustaining mode)


### PR DESCRIPTION
Recommended to add a clarity statement for LTSC

Technically Windows 10 IoT Enterprise is LTSB / LTSC 2015/2016 (as of today)