### PR TITLE
LOB apps - Windows 10 should be yes

### DIFF
--- a/intune/app-management.md
+++ b/intune/app-management.md
@@ -58,7 +58,7 @@ Intune offers a range of capabilities to help you get the apps you need on the d
 |Mandatory install of apps on devices (Required)<sup>2</sup>|Yes|Yes|Yes|Yes|
 |Optional installation on devices from the Company Portal (Available install)|Yes|Yes|Yes|Yes|
 |Install shortcut to an app on the web (web clip)|Yes|Yes|Yes|Yes|
-|In-house (line-of-business) apps|Yes|Yes|No|No|
+|In-house (line-of-business) apps|Yes|Yes|No|Yes|
 |Apps from a store|Yes|Yes|Yes|Yes|
 |Update apps|Yes|Yes|Yes|Yes|
 


### PR DESCRIPTION
In the table referencing capabilities of Intune, LOB (in house apps) is set to No to Windows 10.

This is not entirely true as Intune supports MSIs now and those are called Line of Business apps.
https://docs.microsoft.com/en-us/intune/lob-apps-windows