### PR TITLE
Update app-sdk-xamarin.md

### DIFF
--- a/intune/app-sdk-xamarin.md
+++ b/intune/app-sdk-xamarin.md
@@ -7,7 +7,7 @@ keywords: sdk, Xamarin, intune
 author: erikre
 manager: dougeby
 ms.author: erikre
-ms.date: 11/01/2017
+ms.date: 02/08/2018
 ms.topic: article
 ms.prod:
 ms.service: microsoft-intune

--- a/intune/app-sdk-xamarin.md
+++ b/intune/app-sdk-xamarin.md
@@ -73,7 +73,7 @@ Xamarin apps built with the Intune App SDK Xamarin Component can now receive Int
 
 3.	Download the Intune App SDK Xamarin Component folder from [GitHub](https://github.com/msintuneappsdk/intune-app-sdk-xamarin) or [Nuget.org](https://www.nuget.org/profiles/msintuneappsdk) and extract it. Both files downloaded from step 1 and step 3 should be in the same directory level.
 
-4.	In the command line as an administrator, run `Xamarin.Component.exe install <.xam> file`.
+4.	In the command line as an administrator, run `mono Xamarin.Component.exe install <.xam> file`.
 
 5.	In Visual Studio, right-click **components** in your previously created Xamarin project.
 


### PR DESCRIPTION
These are instructions for MacOS.  Xamarin.Component.exe must be executed using mono, so instead of "Xamarin.Component.exe install <.xam> file" it should be "mono Xamarin.Component.exe install <.xam> file"