### PR TITLE
Update device-remote-lock.md

### DIFF
--- a/intune/device-remote-lock.md
+++ b/intune/device-remote-lock.md
@@ -43,7 +43,7 @@ Remote lock is supported for the following platforms:
 |Android|Yes|
 |iOS|Yes|
 |macOS|Yes|
-|Windows 10|Yes|
+|Windows 10|No|
 |Windows 10 Mobile|Yes|
 |Windows Phone|Yes, for Windows Phone 8.1 and later|
 


### PR DESCRIPTION
We had the same issue in the past with the Intune Silverlight documentation for which I filed an bug with the PG who confirmed that Remote Lock was not supported on Windows 10 Desktop and we had the documentation updated accordingly:
https://docs.microsoft.com/en-us/intune-classic/deploy-use/use-remote-lock-and-passcode-reset-in-microsoft-intune

This is the BUG where the PG confirmed that Remote Lock is not supported for Windows 10 Desktop:

https://msazure.visualstudio.com/Intune/_workitems?id=928686&src=WorkItemMention&src-action=artifact_link&fullScreen=true&_a=edit 

The Windows CSP documentation below also confirms that this is indeed not supported:
https://msdn.microsoft.com/en-us/windows/hardware/commercialize/customize/mdm/configuration-service-provider-reference