### PR TITLE
Change step around notification user during setup

### DIFF
--- a/intune/exchange-connector-install.md
+++ b/intune/exchange-connector-install.md
@@ -122,7 +122,7 @@ Perform the following steps to install the Intune On-premises Exchange Connector
 
     5. In the **User (Domain\user)** and **Password** fields, enter the credentials that are necessary to connect to your Exchange server.
 
-    6.  Provide the necessary credentials to send notifications to a user’s Exchange Server mailbox. This can be a separate user used only for notifications. The user used for notifications will need to have an exchange mailbox to be able to send notifications email. You can configure these notifications with Conditional Access policies in Intune.  
+    6.  Provide the necessary credentials to send notifications to a user’s Exchange Server mailbox. This user can be dedicated to just notifications. The notifications user needs an Exchange mailbox to be able to send notifications by email. You can configure these notifications with conditional access policies in Intune.  
 
         Ensure that the Autodiscover service and Exchange Web Services are configured on the Exchange Client Access Server. For more information, see [Client Access server](https://technet.microsoft.com/library/dd298114.aspx).
 

--- a/intune/exchange-connector-install.md
+++ b/intune/exchange-connector-install.md
@@ -122,7 +122,7 @@ Perform the following steps to install the Intune On-premises Exchange Connector
 
     5. In the **User (Domain\user)** and **Password** fields, enter the credentials that are necessary to connect to your Exchange server.
 
-    6.  Provide the necessary administrative credentials to send notifications to a user’s Exchange Server mailbox. You can configure these notifications with Conditional Access policies in Intune.
+    6.  Provide the necessary credentials to send notifications to a user’s Exchange Server mailbox. This can be a separate user used only for notifications. The user used for notifications will need to have an exchange mailbox to be able to send notifications email. You can configure these notifications with Conditional Access policies in Intune.  
 
         Ensure that the Autodiscover service and Exchange Web Services are configured on the Exchange Client Access Server. For more information, see [Client Access server](https://technet.microsoft.com/library/dd298114.aspx).
 

--- a/intune/exchange-connector-install.md
+++ b/intune/exchange-connector-install.md
@@ -8,7 +8,7 @@ keywords:
 author: msmimart
 ms.author: mimart
 manager: dougeby
-ms.date: 02/26/2018
+ms.date: 03/08/2018
 ms.topic: article
 ms.prod:
 ms.service: microsoft-intune


### PR DESCRIPTION
#MVPHackaDoc
The user used for notification does not need administrative credentials. It only needs an exchange mailbox. Changed Step 6 for setup.