### PR TITLE
Update email-settings-ios.md

### DIFF
--- a/intune/email-settings-ios.md
+++ b/intune/email-settings-ios.md
@@ -37,7 +37,7 @@ This article shows you the email profile settings you can configure for your dev
 - **Account name** - The display name for the email account as it appears to users on their devices.
 - **Username attribute from AAD** - This is the attribute in Active Directory (AD) or Azure AD, that is used to generate the username for this email profile. Select **Primary SMTP Address**, such as **user1@contoso.com** or **User Principal Name**, such as **user1** or **user1@contoso.com**.
 - **Email address attribute from AAD** - How the email address for the user on each device is generated. Select **Primary SMTP Address** to use the primary SMTP address to log into Exchange or use **User Principal Name** to use the full principal name as the email address.
-- **Authentication method** - Select either **Username and Password** or **Certificates** as the authentication method used by the email profile.
+- **Authentication method** - Select either **Username and Password** or **Certificates** as the authentication method used by the email profile (**Note**: Azure Multi-factor authentication is not supported).
 	- If you selected **Certificate**, select a client SCEP or PKCS certificate profile that you previously created that is used to authenticate the Exchange connection.
 - **SSL** - Use Secure Sockets Layer (SSL) communication when sending emails, receiving emails, and communicating with the Exchange server.
 - **S/MIME** - Send outgoing email using S/MIME signing.


### PR DESCRIPTION
Requested by Michael Morales - CSS is getting calls from customers trying to configure e-mail account for native e-mail client on iOS >11  pushed from Intune when MFA is enabled. 
Content Idea Request 79107:iOS Native E-mail client e-mail profile sent from Intune does not support MFA