### PR TITLE
Update device-passcode-reset.md

### DIFF
--- a/intune/device-passcode-reset.md
+++ b/intune/device-passcode-reset.md
@@ -54,7 +54,7 @@ To create a new passcode for a device, use the **Remove passcode** action.
 
 ## Resetting Android for Work passcodes
 
-Supported Android for Work devices receive a new device unlock password or a managed profile challenge for the end user. For devices on Android 7.0 or later with Work profiles, end users receive notifications to activate their reset passcode token immediately after enrollment is completed. The notification is displayed if a Work profile password is required and set. Once their passcode is entered, the notification is dismissed.
+Supported Android for Work devices receive a new managed profile unlock password or a managed profile challenge for the end user. For devices on Android 7.0 or later with Work profiles, end users receive notifications to activate their reset passcode token immediately after enrollment is completed. The notification is displayed if a Work profile password is required and set. Once their passcode is entered, the notification is dismissed.
 
 ## Resetting iOS passcodes
 


### PR DESCRIPTION
Intune can't reset the device password on AFW, only the managed profile password. Tweaking a sentence to reflect this correctly.