### PR TITLE
Added important message about Enhanced IE config

### DIFF
--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -310,7 +310,7 @@ In this task, you:
     After you select the client authentication certificate, you are returned to the **Client Certificate for Microsoft Intune Certificate Connector** surface. Although the certificate you selected is not shown, select **Next** to view the properties of that certificate. Select **Next**, and then **Install**.
     
     > [!IMPORTANT]
-    > The Intune Certificate Connector cannot be enrolled on a machine with the Enhanced Internet Explorer enabled. In order for it to work disable the Enhanced IE option on the machine.
+    > The Intune Certificate Connector can't be enrolled on a device with Internet Explorer Enhanced Security Configuration enabled. To use the Intune Certificate Connector, [disable IE Enhanced security configuration](https://technet.microsoft.com/library/cc775800(v=WS.10).aspx).
 
 7. After the wizard completes, but before closing the wizard, **Launch the Certificate Connector UI**.
 

--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -308,6 +308,9 @@ In this task, you:
 6. When prompted for the client certificate for the Certificate Connector, choose **Select**, and select the **client authentication** certificate you installed on your NDES Server in Task 3.
 
     After you select the client authentication certificate, you are returned to the **Client Certificate for Microsoft Intune Certificate Connector** surface. Although the certificate you selected is not shown, select **Next** to view the properties of that certificate. Select **Next**, and then **Install**.
+    
+    > [!IMPORTANT]
+    > The Intune Certificate Connector cannot be enrolled on a machine with the Enhanced Internet Explorer enabled. In order for it to work disable the Enhanced IE option on the machine.
 
 7. After the wizard completes, but before closing the wizard, **Launch the Certificate Connector UI**.
 


### PR DESCRIPTION
Enhanced IE will prevent the Intune certificate connector from enrolling, so in the step where the user will start the installation process i have added the warning with the added instruction to disable it if they want to enroll the connector on that machine