### PR TITLE
Update device-restrictions-windows-10.md

### DIFF
--- a/intune/device-restrictions-windows-10.md
+++ b/intune/device-restrictions-windows-10.md
@@ -268,9 +268,12 @@ A kiosk device typically runs one app, or a specific set of apps. Users are prev
 #### Single app kiosks
 Enter the following settings:
 
-- **User account** - Enter the local (to the device) user account or the Azure AD account login associated with the kiosk app. For accounts joined to Azure AD domains, enter the account using the `domain\username@tenant.org` format. 
+- **User account** - Enter the local (to the device) user account, an AD or Azure AD account login associated with the kiosk app.
+Local account can be entered as machinename\account or .\account or just account.
+Domain account should be entered as domain\account.
+Azure AD account must be specified in this format: AzureAD\{email address}. AzureAD must be provided AS IS (consider it’s a fixed domain name), then follow with the Azure AD email address, e.g. AzureAD\someone@contoso.onmicrosoft.com.
 
-    For kiosks in public-facing environments with auto logon enabled, a user type with the least privilege (such as the local standard user account) should be used. To configure an Azure Active Directory (AD) account for kiosk mode, use the `AzureAD\user@contoso.com` format.
+    For kiosks in public-facing environments with auto logon enabled, a user type with the least privilege (such as the local standard user account) should be used. 
 
 - **Application user model ID (AUMID) of app** - Enter the AUMID of the kiosk app. To learn more, see [Find the Application User Model ID of an installed app](https://docs.microsoft.com/windows-hardware/customize/enterprise/find-the-application-user-model-id-of-an-installed-app).
 


### PR DESCRIPTION
Taken from the XML example on [this Docs article](https://docs.microsoft.com/en-us/windows/configuration/lock-down-windows-10-to-specific-apps#configure-a-kiosk-in-microsoft-intune)
I suppose Intune is using the same mechanism and therefore has the same user definitions.