### PR TITLE
[Microsoft Internal]Update device-windows-pin-reset.md

### DIFF
--- a/intune/device-windows-pin-reset.md
+++ b/intune/device-windows-pin-reset.md
@@ -32,10 +32,10 @@ You can reset the passcode for Windows devices. The reset passcode feature uses 
 
 ## Supported platforms
 
-- Windows 10 Creators Update and later (Azure AD joined)
+- Windows 10 Mobile running Creators Update and later (Azure AD joined).
 
 The following platforms are **not** supported:
-- Windows Phone
+- Windows
 - iOS
 - macOS
 - Android


### PR DESCRIPTION
Erik Kjerland , suggested me to edit the documentation from GitHub.

According to my research and tests performed on several environments; This feature is only available for Windows 10 Mobile and not for Windows 10 workstations.

Besides, my arguments are based on a TechNet article: https://blogs.technet.microsoft.com/matt_hinsons_manageability_blog/2017/07/26/intune-passcode-reset-microsoft-pin-reset-service/