### PR TITLE
Update screenshot please

### DIFF
--- a/intune/custom-settings-windows-10.md
+++ b/intune/custom-settings-windows-10.md
@@ -55,8 +55,7 @@ The profile is created and appears on the profiles list pane.
 ## Example
 In the following screenshot, the setting **Connectivity/AllowVPNOverCellular** has been enabled. This lets a Windows 10 device open a VPN connection when on a cellular network.
 
-> ![Example of a custom policy containing VPN settings](./media/custom-policy-example.png)
-
+> ![Example of a custom policy containing VPN settings](https://github.com/JankeSkanke/JankeStuff/blob/master/OMAURI1.PNG) 
 
 ## How to find the policies you can configure
 


### PR DESCRIPTION
The screenshot > ![Example of a custom policy containing VPN settings](./media/custom-policy-example.png) is showing the OMA-URI settings from the classic portal, which is going a way soon. Please update screenshot. I have upload a screenshot to my own repo for your convenience. https://github.com/JankeSkanke/JankeStuff/blob/master/OMAURI1.PNG