### PR TITLE
Update app-configuration-policies-managed-app.md

### DIFF
--- a/intune/app-configuration-policies-managed-app.md
+++ b/intune/app-configuration-policies-managed-app.md
@@ -53,7 +53,7 @@ Intune App SDK-enabled apps support configurations in key/value pairs. To learn 
 
 Intune can generate certain tokens and send them to the managed application. For example, if your app configuration can use an email setting, you can add a dynamic email by using a token. Type the name expected by the app in the **Name** field, and then type `\{\{mail\}\}` in the **Value** field.
 
-Intune supports the following token types in the configuration settings:
+Intune supports the following token types in the configuration settings. Other custom key/value pairs are not supported.
 
 - \{\{userprincipalname\}\}—for example, **John@contoso.com**
 - \{\{mail\}\}—for example, **John@contoso.com**


### PR DESCRIPTION
Approved in CSS content triage - Content Idea Request 84947: At the bottom of the article, added a sentence after the introductory sentence to the list of token types: "Other custom key/value pairs are not supported."