### PR TITLE
Update app-configuration-policies-use-ios.md

### DIFF
--- a/intune/app-configuration-policies-use-ios.md
+++ b/intune/app-configuration-policies-use-ios.md
@@ -152,7 +152,7 @@ Intune supports the following data types in a property list:
 
 ### Tokens used in the property list
 
-Additionally, Intune supports the following token types in the property list:
+Additionally, Intune supports the following token types in the property list. Other custom key/value pairs are not supported."
 - \{\{userprincipalname\}\}—for example, **John@contoso.com**
 - \{\{mail\}\}—for example, **John@contoso.com**
 - \{\{partialupn\}\}—for example, **John**


### PR DESCRIPTION
Approved in CSS content triage - Content Idea Request 84948: At the bottom of the article, added a second sentence after the introductory sentence to the list of token types:  "Other custom key/value pairs are not supported."