### PR TITLE
Updated example scenario for DEM

### DIFF
--- a/intune/device-enrollment-manager-enroll.md
+++ b/intune/device-enrollment-manager-enroll.md
@@ -39,7 +39,7 @@ Users must exist in the [Azure portal](https://portal.azure.com) to be added as 
 
 ## Example of a device enrollment manager scenario
 
-A restaurant wants to provide 50 point-of-sale tablets for its wait staff, and order monitors for its kitchen staff. The employees never need to access company data or sign in as users. The Intune admin creates a device enrollment manager account and adds a restaurant supervisor to the DEM account. The supervisor now has DEM capabilities. The supervisor can now enroll the 50 tablets devices by using the DEM credentials.
+A restaurant wants to provide 50 point-of-sale tablets for its wait staff, and order monitors for its kitchen staff. The employees never need to access company data or sign in as users. The Intune admin creates a new device enrollment manager account for the restaurant supervisor.  This account is separate from the supervisor's primary account, and used only for the purpose of enrolling shared devices with Intune. The supervisor can now enroll the 50 tablets devices by using the DEM credentials.
 
 Only users in the [Azure portal](https://portal.azure.com) can be device enrollment managers. The device enrollment manager user cannot be an Intune admin.
 


### PR DESCRIPTION
The old wording implies that a DEM account is created and the supervisor somehow 'added to' that account, giving the supervisor DEM rights.  The way it actually works is a new DEM account is created, and the supervisor can use that account to enroll devices.  It's not like adding an existing user to a group to grant the user DEM permissions, it's a second account for that user which is used only for DEM purposes.