### PR TITLE
Add information to Import

### DIFF
--- a/intune/enrollment-autopilot.md
+++ b/intune/enrollment-autopilot.md
@@ -38,6 +38,9 @@ You can add Windows AutoPilot devices by importing a CSV file with their informa
 
 3. Choose **Import** to start importing the device information. Importing can take several minutes.
 
+>[!NOTE] 
+> After import completes you will need to Synchronize Devices before they appear in the inventory.
+
 ## Synchronize devices
 Synchronize your registered devices into Intune so that you can configure them.
 


### PR DESCRIPTION
A sync must still be performed after importing devices before they will appear in inventory. This can cause confusion for admins new to the dashboard as it is not called out in the docs.