### PR TITLE
Fix Click-to-Run references; add link to article

### DIFF
--- a/intune/apps-add-office365.md
+++ b/intune/apps-add-office365.md
@@ -100,7 +100,7 @@ In this step, configure installation options for the app suite. The settings app
 		- **Semi-Annual**
 		- **Semi-Annual (Targeted)**
 	- **Automatically accept the app end user license agreement**: Select this option if you don't require end users to accept the license agreement. Intune then automatically accepts the agreement.
-	- **Use shared computer activation**: Select this option when multiple users share a computer. For more information, see Overview of shared computer activation for Office 365.
+	- **Use shared computer activation**: Select this option when multiple users share a computer. For more information, see [Overview of shared computer activation for Office 365](https://docs.microsoft.com/DeployOffice/overview-of-shared-computer-activation-for-office-365-proplus).
 	- **Languages**: Office is automatically installed in any supported languages that are installed with Windows on the end-user's device. Select this option if you want to install additional languages with the app suite.
 
 >[!IMPORTANT]
@@ -125,7 +125,7 @@ The following tables list common error codes you might encounter and their meani
 |997|WIP|Installing|
 |0|After installation|Installation succeeded|	 
 |1603 (ERROR_INSTALL_FAILURE)|-|Failed any prerequisite check, such as:<ul><li>SxS (Tried to install when 2016 MSI is installed)</li><li>Version mismatch</li><li>Others</li></ul>|	 
-|0x8000ffff (E_UNEXPECTED)|-|Tried to uninstall when there is no Click-to-run Office on the machine|	 
+|0x8000ffff (E_UNEXPECTED)|-|Tried to uninstall when there is no Click-to-Run Office on the machine|	 
 |17002|-|Failed to complete the scenario (install). Possible reasons:<ul><li>Installation canceled by user</li><li>Installation canceled by another installation</li><li>Out of disk space during installation</li><li>Unknown language ID</li></ul>|
 |17004|-|Unknown SKUs|	 
 
@@ -135,14 +135,14 @@ The following tables list common error codes you might encounter and their meani
 |||||
 |-|-|-|-|
 |Scenario|Return code|UI|Note|
-|Uninstall effort when there is no active Click-to-run installation|-2147418113, 0x8000ffff or 2147549183|Error Code: 30088-1008<br>Error Code: 30125-1011 (404)|Office Deployment Tool|
+|Uninstall effort when there is no active Click-to-Run installation|-2147418113, 0x8000ffff or 2147549183|Error Code: 30088-1008<br>Error Code: 30125-1011 (404)|Office Deployment Tool|
 |Install when there is MSI version installed|1603|-|Office Deployment Tool|
-|Installation canceled by user, or by another installation|17002|-|Click-to-run|
+|Installation canceled by user, or by another installation|17002|-|Click-to-Run|
 |Try to install 64-bit on a device that has 32-bit installed.|1603|-|Office Deployment Tool return code|
-|Try to install an unknown SKU (not a legitimate use case for Office CSP since we should only pass in valid SKUs)|17004|-|Click-to-run|
-|Lack of space|17002|-|Click-to-run|
-|The click-to-run client failed to start (unexpected)|17000|-|Click-to-run|
-|The click-to-run client failed to queue scenario (unexpected)|17001|-|Click-to-run|
+|Try to install an unknown SKU (not a legitimate use case for Office CSP since we should only pass in valid SKUs)|17004|-|Click-to-Run|
+|Lack of space|17002|-|Click-to-Run|
+|The Click-to-Run client failed to start (unexpected)|17000|-|Click-to-Run|
+|The Click-to-Run client failed to queue scenario (unexpected)|17001|-|Click-to-Run|
 
 ## Next steps
 


### PR DESCRIPTION
Link to "Overview of shared computer activation" article was missing. Also, corrected capitalization of Click-to-Run references