### PR TITLE
broken link when published to docs.microsoft.com

### DIFF
--- a/intune/android-work-profile-enroll.md
+++ b/intune/android-work-profile-enroll.md
@@ -39,7 +39,7 @@ To set up Android work profile management, follow these steps:
 2. Specify Android work profile enrollment settings. Android work profiles are [supported on only certain Android devices](https://support.google.com/work/android/answer/6174145?hl=en&ref_topic=6151012%20style=%22target=new_window%22). Any device that supports Android work profiles also supports conventional Android management. Intune lets you specify how devices that support Android work profiles should be managed from within [Enrollment Restrictions](enrollment-restrictions-set.md).
     - **Block (set by default)**:  All Android devices, including devices that support Android work profiles, will be enrolled as conventional Android devices.
     - **Allow**: All devices that support Android work profiles are enrolled as Android work profile devices. Any Android device that does not support Android work profiles is enrolled as a conventional Android device.
-3. [Tell your users how to enroll their devices](/intune-user-help/enroll-your-device-in-intune-android.md).
+3. [Tell your users how to enroll their devices](/intune-user-help/enroll-your-device-in-intune-android).
 
 
 If you want to enroll devices in Android work profiles, but those devices were already enrolled as regular Android devices, those devices must first unenroll and then re-enroll.


### PR DESCRIPTION
when viewed via docs.microsoft.com domain the link was broken due the .md at the end. Published it looked like this:
https://docs.microsoft.com/en-us/intune-user-help/enroll-your-device-in-intune-android.md
but must be this:
https://docs.microsoft.com/en-us/intune-user-help/enroll-your-device-in-intune-android
I think because of the prefix /intune-user-help/ the .md link is not correctly replaced.
/intune-user-help/enroll-your-device-in-intune-android.md
therefore changing it to 
/intune-user-help/enroll-your-device-in-intune-android
this should work on the published site.