### PR TITLE
Remove MacOS reference in App Licenses

### DIFF
--- a/intune/apps-add.md
+++ b/intune/apps-add.md
@@ -112,7 +112,7 @@ Intune-managed apps can also enable app protection without requiring enrollment,
 
 ### Understanding licensed apps
 In addition to understanding web apps, store apps, and LOB apps, you should also be aware of the destination of volume-purchase-program apps and licensed apps, such as: 
-- **Apple Volume Purchasing Program for Business (iOS and MacOS)**: The iOS App Store lets you purchase multiple licenses for an app that you want to run in your company. Purchasing multiple copies helps you to efficiently manage apps in your company. For more information, see [Manage iOS volume-purchased apps](vpp-apps-ios.md).
+- **Apple Volume Purchasing Program for Business (iOS)**: The iOS App Store lets you purchase multiple licenses for an app that you want to run in your company. Purchasing multiple copies helps you to efficiently manage apps in your company. For more information, see [Manage iOS volume-purchased apps](vpp-apps-ios.md).
 - **Android work profile**: How you assign apps to Android work profile devices differs from how you assign them to standard Android devices. All apps you install for Android work profiles come from the Managed Google Play store. You sign in to the store, browse for the apps you want, and approve them. The app then appears in the **Licensed apps** node of the Azure portal, and you can manage assignment of the app as you would any other app.
 - **Microsoft Store for Business (Windows 10)**: Microsoft Store for Business gives you a place to find and purchase apps for your organization, individually or in volume. By connecting the store to Microsoft Intune, you can manage volume-purchased apps in the Azure portal. For more information, see [Manage apps from Microsoft Store for Business](windows-store-for-business.md).
 


### PR DESCRIPTION
Remove MacOS reference in Apple VPP as it's not supported currently by Intune.