### PR TITLE
Update corporate-identifiers-add.md

### DIFF
--- a/intune/corporate-identifiers-add.md
+++ b/intune/corporate-identifiers-add.md
@@ -37,7 +37,7 @@ At the time of enrollment, Intune automatically assigns corporate-owned status t
 - Enrolled with a [device enrollment manager](device-enrollment-manager-enroll.md) account (all platforms)
 - Enrolled with the Apple [Device Enrollment Program](device-enrollment-program-enroll-ios.md), [Apple School Manager](apple-school-manager-set-up-ios.md), or [Apple Configurator](apple-configurator-enroll-ios.md) (iOS only)
 - [Identified as corporate-owned before enrollment](#identify-corporate-owned-devices-with-imei-or-serial-number) with an international mobile equipment identifier (IMEI) numbers (all platforms with IMEI numbers) or serial number (iOS and Android)
-- Registered in Azure Active Directory or Enterprise Mobility + Security as a Windows 10 Enterprise device
+- Joined to Azure Active Directory as a Windows 10 Enterprise device
 - Set as corporate in the [device's properties list](#change-device-ownership)
 
 After enrollment, you can [change the ownership setting](#change-device-ownership) between **Personal** and **Corporate**.


### PR DESCRIPTION
confirmed via testing that Intune will only mark a Windows 10 device as corporate when it is Joined to AAD, the use of word Registered implied you could just add the Work account to the device (since that causes it to show registered in AAD)