### PR TITLE
Update app-protection-policies.md

### DIFF
--- a/intune/app-protection-policies.md
+++ b/intune/app-protection-policies.md
@@ -60,7 +60,7 @@ For information about adding your organization's line-of-business (LOB) apps to 
    To get you started, the policy settings have default values. If the default values meet your requirements, you don't have to make any changes.
 
    > [!TIP]
-   > These policy settings are enforced only when using apps in the work context. When end users use the app to do a personal task, they aren't affected by these policies.
+   > These policy settings are enforced only when using apps in the work context. When end users use the app to do a personal task, they aren't affected by these policies. Note that when you create a new file it is considered a personal file. 
 
 7. Choose **OK** to save this configuration. You're now back in the **Add a policy** blade.
 8. Choose **Create** to create the policy and save your settings.


### PR DESCRIPTION
Approved in CSS triage - CONTENT IDEA REQUEST 91602. In an environment where Intune App Protection policies are applying to Office apps (Android and iOS), even if users login to this apps with a user account protected by Intune App Protection policies, when creating a brand new file (such as word document) it is considered as a personal file until it is saved in a corporate location (such as OneDrive for Business/Sharepoint Online). Hence, if administrators have settings Restricting Copy Paste or Preventing Save As, these settings will not be enforced on a brand new file. 
After this file is saved on a corporate location (such as OneDrive for Business/Sharepoint Online), it is tagged as a corporate file, so all the restrictions from Intune App Protection Policy will apply.

Not having this information explicit in the documentation has caused some confusion to customers. I have worked on 3 different calls with similar questions (the most recent is 118091719021276). Please add a segment explaining the implications of creating new files and the differences between Personal Files and Corporate Files, while working on managed applications.