### PR TITLE
Correcting SCCM Data Sharing description

### DIFF
--- a/intune/privacy-data-secure-share.md
+++ b/intune/privacy-data-secure-share.md
@@ -71,7 +71,7 @@ For information about data shared with certain third parties, see the following 
 
 ### System Center Configuration Manager data sharing
 
-Microsoft Intune does not share any data with the System Center Configuration Manager. Microsoft Intune is an on-premise product deployed, managed, and operated directly by the customer. The diagnostics and usage data that is collected by Configuration Manager are only to improve the installation experience, quality, and security of future releases.
+Microsoft Intune does not share any data with the System Center Configuration Manager. System Center Configuration Manager is an on-premise product deployed, managed, and operated directly by the customer. The diagnostics and usage data that is collected by Configuration Manager are only to improve the installation experience, quality, and security of future releases.
 
 To learn more, see [Diagnostics and usage data for SCCM](https://docs.microsoft.com/en-us/sccm/core/plan-design/diagnostics/diagnostics-and-usage-data.md). 
 


### PR DESCRIPTION
The second sentence under "System Center Configuration Manager data sharing" is incorrect (i.e. Intune is not an on-premises product...). I think the sentence is meant to speak about SCCM.