### PR TITLE
Update app-configuration-policies-outlook.md

### DIFF
--- a/intune/app-configuration-policies-outlook.md
+++ b/intune/app-configuration-policies-outlook.md
@@ -6,6 +6,7 @@ description: Create a configuration policy to set Microsoft Outlook settings run
 keywords:
 author: Erikre
 ms.author: erikre
+ms.reviewer: smithre4
 manager: dougeby
 ms.date: 10/04/2018
 ms.topic: article
@@ -34,27 +35,15 @@ To create an app configuration policy for managed iOS devices, see [Add app conf
 
 When adding a configuration policy in Intune, you can set specific settings to configure Microsoft Outlook. In the **Configuration settings** pane you can set the email account configuration.
 
-### Email account settings
+### Basic authentication email account settings
+Outlook for iOS and Android offers Exchange administrators the ability to "push" account configurations to their on-premises users who use Basic authentication with the ActiveSync protocol. For more information, please see [Account setup in Outlook for iOS and Android using Basic authentication](https://docs.microsoft.com/en-us/Exchange/clients/outlook-for-ios-and-android/account-setup). To enable account setup configuration, you can configure the following settings:
 
-The following configuration settings are specific to Microsoft Outlook.
-
-- **Email server**: Enter the host name of your Exchange server.
+- **Email server**: Enter the host name of your on-premises Exchange server (e.g., mail.contoso.com).
 - **Email account name**: Enter the display name for the email account. This name is shown to users on their devices.
-- **Username attribute from AAD**: This name is the attribute Intune gets from Azure Active Directory (AAD). Intune dynamically generates the username that's used by this profile. Your options:
+- **Username attribute from AAD**: This name is the attribute Intune gets from Azure Active Directory (AAD). Intune dynamically generates the username that's used by this profile. Your options include:
   - **User Principal Name**: Gets the name, such as `user1` or `user1@contoso.com`
   - **Primary SMTP address**: Gets the name in email address format, such as `user1@contoso.com`
-  - **sAM Account Name**: Requires the domain, such as `domain\user1`.
-
-    Also enter:  
-    - **User domain name source**: Choose **AAD** (Azure Active Directory) or **Custom**.
-
-      When choosing to get the attributes from **AAD**, enter:
-      - **User domain name attribute from AAD**: Choose to get the **Full domain name** or the **NetBIOS name** attribute of the user
-
-      When choosing to use **Custom** attributes, enter:
-      - **Custom domain name to use**: Enter a value that Intune uses for the domain name, such as `contoso.com` or `contoso`
-
-- **Email address attribute from AAD**: Choose how the email address for the user is generated. Select **User principal name** (`user1@contoso.com` or `user1`) to use the full principal name as the email address, or **Primary SMTP address** (`user1@contoso.com`) to use the primary SMTP address to sign in to Exchange.
+- **Email address attribute from AAD**: Choose how the email address for the user is generated. Select **User principal name** (`user1@contoso.com` or `user1`) to use the full principal name as the email address, or **Primary SMTP address** (`user1@contoso.com`) to use the primary SMTP address to sign in to Exchange. The recommendation is to select **Primary SMTP address**.
 - **Account domain**: (Optional) The domain of the account.
 
 ## Next steps


### PR DESCRIPTION
Updated description to include that this focuses on basic auth experience only.

Removed sAM Account Name: Requires the domain, such as domain\user1. as that is an option in the drop-down (that's a bug as it should be there)

Removed 

Also enter:

    User domain name source: Choose AAD (Azure Active Directory) or Custom.

    When choosing to get the attributes from AAD, enter:
        User domain name attribute from AAD: Choose to get the Full domain name or the NetBIOS name attribute of the user

    When choosing to use Custom attributes, enter:
        Custom domain name to use: Enter a value that Intune uses for the domain name, such as contoso.com or contoso

As those options don't exist in the UX.