### PR TITLE
Update this article

### DIFF
--- a/intune/certficates-pfx-configure.md
+++ b/intune/certficates-pfx-configure.md
@@ -122,6 +122,9 @@ To authenticate with VPN, WiFi, or other resources, a root, or intermediate CA c
 
 ![ConnectorDownload][ConnectorDownload]
 
+ > [!NOTE]
+ > Microsoft Intune Certificate Connector MUST be installed on a separate Windows server. It can NOT be installed on the issuing CA.
+
 1. Sign in to the [Azure portal](https://portal.azure.com).
 2. Select **All services**, filter on **Intune**, and select **Microsoft Intune**.
 3. Select **Device configuration**, and then select **Certification Authority**.


### PR DESCRIPTION
We forgot to mention that NDESConnector need to be  installed on a separate server other than issuing CA, I have a customer which followed this guide and installed the NDESConnector on the issuing CA and that caused problem, so customer request to correct the DOC. This have been mentioned in SCEP DOC but not in PKCS DOC here