### PR TITLE
Most image links are broken due to case mismatch

### DIFF
--- a/intune-user-help/enroll-your-device-in-intune-ios.md
+++ b/intune-user-help/enroll-your-device-in-intune-ios.md
@@ -65,34 +65,34 @@ To learn more about enrollment, see [What happens when I install the Company Por
 
 |What you see|Explanation|
 |---|---|
-|![Company Portal sign-in screen, with "Sign in" button on bottom.](./media/ios-01-cp-enroll-1802.png)|Open the Company Portal app and tap **Sign In**.|
-|![Azure AD sign-in prompt.](./media/ios-02-cp-enroll-1802.png)|Enter your company email address, then tap **Next**.|
-|![Azure AD password prompt.](./media/ios-03-cp-enroll-1802.png)|Enter your password, then tap **Sign in**.|
-|![Loading company resources splash screen.](./media/ios-04-cp-enroll-1802.png)|Wait for this screen to load.|
-|![Terms and conditions page.](./media/ios-05-cp-enroll-1802.png)|Read and **Accept All** of the Terms and Conditions.|
-|![Set up company access screen. Both management and settings are currently in need of resolution.](./media/ios-06-cp-enroll-1802.png)|Tap on **Begin** to begin the process of making your device able to access company resources. If you can't do this right now, you can **Postpone** the process, but it means you won't be able to get email, documents, and more.|
-|![What can my company see screen.](./media/ios-07-cp-enroll-1802.png)|You can **Learn more** about what your company can see by tapping the link at the bottom. Otherwise, tap **Continue**.|
-|![What's next screen.](./media/ios-08-cp-enroll-1802.png)|This screen walks you through what's happening in the setup. You'll spend time in Safari, the Settings app, and the Company Portal app. Tap **Continue**.|
-|![Loading screen after tapping Next on What's next.](./media/ios-09-cp-enroll-1802.png)|Wait for this screen to load.|
+|![Company Portal sign-in screen, with "Sign in" button on bottom.](./media/ios-01-cp-enroll-1802.PNG)|Open the Company Portal app and tap **Sign In**.|
+|![Azure AD sign-in prompt.](./media/ios-02-cp-enroll-1802.PNG)|Enter your company email address, then tap **Next**.|
+|![Azure AD password prompt.](./media/ios-03-cp-enroll-1802.PNG)|Enter your password, then tap **Sign in**.|
+|![Loading company resources splash screen.](./media/ios-04-cp-enroll-1802.PNG)|Wait for this screen to load.|
+|![Terms and conditions page.](./media/ios-05-cp-enroll-1802.PNG)|Read and **Accept All** of the Terms and Conditions.|
+|![Set up company access screen. Both management and settings are currently in need of resolution.](./media/ios-06-cp-enroll-1802.PNG)|Tap on **Begin** to begin the process of making your device able to access company resources. If you can't do this right now, you can **Postpone** the process, but it means you won't be able to get email, documents, and more.|
+|![What can my company see screen.](./media/ios-07-cp-enroll-1802.PNG)|You can **Learn more** about what your company can see by tapping the link at the bottom. Otherwise, tap **Continue**.|
+|![What's next screen.](./media/ios-08-cp-enroll-1802.PNG)|This screen walks you through what's happening in the setup. You'll spend time in Safari, the Settings app, and the Company Portal app. Tap **Continue**.|
+|![Loading screen after tapping Next on What's next.](./media/ios-09-cp-enroll-1802.PNG)|Wait for this screen to load.|
 |![Switched out to Safari for enrolling.](./media/ios-cp-sent-to-safari-1808.png)|You're sent to Safari to get management information for your device.|
-|![System prompt to ask for Settings app to be opened.](./media/ios-8-cp-enroll-1711.png)|Tap **Allow** to open the Settings app to download the configuration profile. You install this to let your company manage corporate information on your device.|
-|![Scressnhot of the Install Profile screen in device settings.](./media/ios-9-cp-enroll-1711.png)|Tap **Install**.|
-|![Installing profile modal dialog from bottom of screen.](./media/ios-10-cp-enroll-1711.png)|Tap **Install**.|
-|![Profile is installing loading screen.](./media/ios-11-cp-enroll-1711.png)|Wait for this screen to load.|
-|![Profile management warning screen.](./media/ios-12-cp-enroll-1711.png)|This warning, written by Apple, lets you know more about what types of actions could be taken on a device under management. Find out more about [what information your company can see](what-info-can-your-company-see-when-you-enroll-your-device-in-intune.md).|
-|![System prompt asking about trust on remote management.](./media/ios-13-cp-enroll-1711.png)|Tap **Trust** to allow your company to manage corporate information and settings on your device.|
-|![Profile finishing installing load screen.](./media/ios-14-cp-enroll-1711.png)|Wait for this screen to load.|
-|![Profile installed screen.](./media/ios-15-cp-enroll-1711.png)|Your profile is installed and your device's corporate information and settings are much closer to being managed.|
-|![Switched out to Safari for enrolling.](./media/ios-16-cp-enroll-1711.png)|You're sent back to Safari to finish getting management information for your device. |
-|![System prompt to open company portal.](./media/ios-17-cp-enroll-1711.png)|Tap **Open**.|
-|![Loading company resources screen.](./media/ios-21-cp-enroll-1802.png)|Wait for this screen to load.|
-|![Select device category in company portal app.](./media/ios-22-cp-enroll-1802.png)|Select the best category for your device. This usually has to do with who owns the device, or where it's located most of the time.|
-|![Category selected.](./media/ios-23-cp-enroll-1802.png)||
-|![Device management successful; now need to update settings.](./media/ios-24-cp-enroll-1802.png)|You've successfully gotten your device managed. There are likely still settings, like the length of your password, that your company may need you to update. Tap **Continue** to proceed.|
-|![Confirming device settings.](./media/ios-25-cp-enroll-1802.png)|Company Portal will check to see if any of your settings need to be updated.|
-|![Settings check finished, with an incorrect OS version](./media/ios-26-cp-enroll-1802.png)|Company Portal will provide instructions on how you can fix any issues with your settings. Once you finish fixing the issues, tap **Check Settings**.|
-|![Confirming device settings loading screen](./media/ios-27-cp-enroll-1802.png)|Your device will check to see if your settings are secure enough to access company resources.|
-|![Successfully enrolled and updated settings](./media/ios-28-cp-enroll-1802.png)|Congratulations! Your device is now enrolled in Intune.|
+|![System prompt to ask for Settings app to be opened.](./media/ios-8-cp-enroll-1711.PNG)|Tap **Allow** to open the Settings app to download the configuration profile. You install this to let your company manage corporate information on your device.|
+|![Scressnhot of the Install Profile screen in device settings.](./media/ios-9-cp-enroll-1711.PNG)|Tap **Install**.|
+|![Installing profile modal dialog from bottom of screen.](./media/ios-10-cp-enroll-1711.PNG)|Tap **Install**.|
+|![Profile is installing loading screen.](./media/ios-11-cp-enroll-1711.PNG)|Wait for this screen to load.|
+|![Profile management warning screen.](./media/ios-12-cp-enroll-1711.PNG)|This warning, written by Apple, lets you know more about what types of actions could be taken on a device under management. Find out more about [what information your company can see](what-info-can-your-company-see-when-you-enroll-your-device-in-intune.md).|
+|![System prompt asking about trust on remote management.](./media/ios-13-cp-enroll-1711.PNG)|Tap **Trust** to allow your company to manage corporate information and settings on your device.|
+|![Profile finishing installing load screen.](./media/ios-14-cp-enroll-1711.PNG)|Wait for this screen to load.|
+|![Profile installed screen.](./media/ios-15-cp-enroll-1711.PNG)|Your profile is installed and your device's corporate information and settings are much closer to being managed.|
+|![Switched out to Safari for enrolling.](./media/ios-16-cp-enroll-1711.PNG)|You're sent back to Safari to finish getting management information for your device. |
+|![System prompt to open company portal.](./media/ios-17-cp-enroll-1711.PNG)|Tap **Open**.|
+|![Loading company resources screen.](./media/ios-21-cp-enroll-1802.PNG)|Wait for this screen to load.|
+|![Select device category in company portal app.](./media/ios-22-cp-enroll-1802.PNG)|Select the best category for your device. This usually has to do with who owns the device, or where it's located most of the time.|
+|![Category selected.](./media/ios-23-cp-enroll-1802.PNG)||
+|![Device management successful; now need to update settings.](./media/ios-24-cp-enroll-1802.PNG)|You've successfully gotten your device managed. There are likely still settings, like the length of your password, that your company may need you to update. Tap **Continue** to proceed.|
+|![Confirming device settings.](./media/ios-25-cp-enroll-1802.PNG)|Company Portal will check to see if any of your settings need to be updated.|
+|![Settings check finished, with an incorrect OS version](./media/ios-26-cp-enroll-1802.PNG)|Company Portal will provide instructions on how you can fix any issues with your settings. Once you finish fixing the issues, tap **Check Settings**.|
+|![Confirming device settings loading screen](./media/ios-27-cp-enroll-1802.PNG)|Your device will check to see if your settings are secure enough to access company resources.|
+|![Successfully enrolled and updated settings](./media/ios-28-cp-enroll-1802.PNG)|Congratulations! Your device is now enrolled in Intune.|
 
 > [!Note]
 > You may have a few more steps to complete before your device is fully managed. Find out more about [enrolling your device using telecom expense management](enroll-your-device-with-telecom-expense-management-ios.md). If your organization is using Apple's Device Enrollment Program, find out more [here](enroll-your-device-dep-ios.md).


### PR DESCRIPTION
Replaced .png with .PNG which matches the case of the file extension for uploaded images with the exception of line 77 where ios-cp-sent-to-safari-1808.png is correct.