### PR TITLE
Correcting bad link

### DIFF
--- a/intune/android-work-profile-enroll.md
+++ b/intune/android-work-profile-enroll.md
@@ -61,5 +61,5 @@ Follow these steps to approve the Intune Company Portal:
 5.  Select **Keep approved when app requests new permissions**, then click **Save.**
 
 ## Next steps for Android work profiles
-- [Deploy Android work profile apps](store-apps-android.md)
+- [Deploy Android work profile apps](apps-add-android-for-work.md)
 - [Add Android work profile configuration policies](device-profiles.md)


### PR DESCRIPTION
The link was incorrectly modified to point to legacy Android apps.  For work profiles, apps must come from managed Play.