### PR TITLE
Change ownerTypeName from Company to Corporate

### DIFF
--- a/intune/reports-ref-devices.md
+++ b/intune/reports-ref-devices.md
@@ -132,7 +132,7 @@ The **EnrollmentTypes** entity indicates whether a device is corporate, personal
 | ownerTypeName |Represents the owner type of the devices:  <br>Corporate - device is enterprise owned. <br>Personal - device is personally owned (BYOD).  <br>Unknown - no information on this device. |Corporate Personal Unknown |
 
 > [!Note]  
-> For the ownerTypeName in AzureAD when creating Dynamic Groups for devices you need to set the filter value deviceOwnership as "Company". Refer to [Rules for devices](https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/groups-dynamic-membership#rules-for-devices) for more details. 
+> For the `ownerTypeName` in AzureAD when creating Dynamic Groups for devices, you need to set the filter value `deviceOwnership` as `Company`. For more information, see [Rules for devices](https://docs.microsoft.com/azure/active-directory/users-groups-roles/groups-dynamic-membership#rules-for-devices). 
 
 ## MdmStatuses
 

--- a/intune/reports-ref-devices.md
+++ b/intune/reports-ref-devices.md
@@ -129,7 +129,10 @@ The **EnrollmentTypes** entity indicates whether a device is corporate, personal
 |---------|------------|--------|
 | ownerTypeID |Unique identifier of the owner type. | |
 | ownerTypeKey |Unique identifier of the owner type in the data warehouse - surrogate key. | |
-| ownerTypeName |Represents the owner type of the devices:  <br>Company - device is enterprise owned. <br>Personal - device is personally owned (BYOD).  <br>Unknown - no information on this device. |Company Personal Unknown |
+| ownerTypeName |Represents the owner type of the devices:  <br>Corporate - device is enterprise owned. <br>Personal - device is personally owned (BYOD).  <br>Unknown - no information on this device. |Corporate Personal Unknown |
+
+> [!Note]  
+> For the ownerTypeName in AzureAD when creating Dynamic Groups for devices you need to set the filter value deviceOwnership as "Company". Refer to [Rules for devices](https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/groups-dynamic-membership#rules-for-devices) for more details. 
 
 ## MdmStatuses
 


### PR DESCRIPTION
In Intune the device ownership appear as Corporate not Company. 
Company apply only for Azure AD value when creating dynamic groups for devices.