### PR TITLE
Add note for the Content type to sync

### DIFF
--- a/intune/email-settings-android.md
+++ b/intune/email-settings-android.md
@@ -90,5 +90,8 @@ As an Intune administrator, you can create and assign email settings to the foll
   - **Calendar**
   - **Tasks**
 
+> [!Note]  
+> For the "Content type to Sync" in the Samsung Knox email profile the setting: "Not Configured", will be equal to Disabled.
+
 ## Next steps
 [Configure email settings in Intune](email-settings-configure.md)


### PR DESCRIPTION
In Intune admin portal when an Android Email profile is created for Knox the settings available are "Enable" and "Not Configured" but the  actions defined on the code is Disable. 

The note is with the intention to clarify the action on the background and prevent confusions for customers and support team.