### PR TITLE
Added more detailed information about SCEP server URL

### DIFF
--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -489,7 +489,7 @@ To validate that the service is running, open a browser, and enter the following
    - **Extended key usage**: **Add** values for the certificate's intended purpose. In most cases, the certificate requires **Client Authentication** so that the user or device can authenticate to a server. However, you can add any other key usages as required.
    - **Enrollment Settings**
      - **Renewal threshold (%)**: Enter the percentage of the certificate lifetime that remains before the device requests renewal of the certificate.
-     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issue certificates via SCEP. For example, enter something similar to https://ndes.contoso.com/certsrv/mscep/mscep.dll.
+     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issue certificates via SCEP. For example, enter something similar to `https://ndes.contoso.com/certsrv/mscep/mscep.dll`.
      - Select **OK**, and **Create** your profile.
 
 The profile is created and appears on the profiles list pane.

--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -489,7 +489,7 @@ To validate that the service is running, open a browser, and enter the following
    - **Extended key usage**: **Add** values for the certificate's intended purpose. In most cases, the certificate requires **Client Authentication** so that the user or device can authenticate to a server. However, you can add any other key usages as required.
    - **Enrollment Settings**
      - **Renewal threshold (%)**: Enter the percentage of the certificate lifetime that remains before the device requests renewal of the certificate.
-     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issues certificates via SCEP including "/certsrv/mscep/mscep.dll". E.G.: "https://ndes.contoso.com/certsrv/mscep/mscep.dll" 
+     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issues certificates via SCEP, including "/certsrv/mscep/mscep.dll". E.G.: "https://ndes.contoso.com/certsrv/mscep/mscep.dll" 
      - Select **OK**, and **Create** your profile.
 
 The profile is created and appears on the profiles list pane.

--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -489,7 +489,7 @@ To validate that the service is running, open a browser, and enter the following
    - **Extended key usage**: **Add** values for the certificate's intended purpose. In most cases, the certificate requires **Client Authentication** so that the user or device can authenticate to a server. However, you can add any other key usages as required.
    - **Enrollment Settings**
      - **Renewal threshold (%)**: Enter the percentage of the certificate lifetime that remains before the device requests renewal of the certificate.
-     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issues certificates via SCEP.
+     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issues certificates via SCEP including "/certsrv/mscep/mscep.dll". E.G.: "https://ndes.contoso.com/certsrv/mscep/mscep.dll" 
      - Select **OK**, and **Create** your profile.
 
 The profile is created and appears on the profiles list pane.

--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -489,7 +489,7 @@ To validate that the service is running, open a browser, and enter the following
    - **Extended key usage**: **Add** values for the certificate's intended purpose. In most cases, the certificate requires **Client Authentication** so that the user or device can authenticate to a server. However, you can add any other key usages as required.
    - **Enrollment Settings**
      - **Renewal threshold (%)**: Enter the percentage of the certificate lifetime that remains before the device requests renewal of the certificate.
-     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issues certificates via SCEP, including "/certsrv/mscep/mscep.dll". E.G.: "https://ndes.contoso.com/certsrv/mscep/mscep.dll" 
+     - **SCEP Server URLs**: Enter one or more URLs for the NDES Servers that issue certificates via SCEP. For example, enter something similar to https://ndes.contoso.com/certsrv/mscep/mscep.dll.
      - Select **OK**, and **Create** your profile.
 
 The profile is created and appears on the profiles list pane.


### PR DESCRIPTION
Added example and mentioned to the need of "/certsrv/mscep/mscep.dll" on SCEP server URL when creating the certificate configuration policy in Azure. 