### PR TITLE
Hidden Network Feature description

### DIFF
--- a/intune/wi-fi-settings-ios.md
+++ b/intune/wi-fi-settings-ios.md
@@ -39,13 +39,13 @@ This article describes these settings.
 
 [Create a device profile](device-profile-create.md).
 
-## Basic profile
+## Basic profiles
 
 - **Wi-Fi type**: Choose **Basic**.
 - **Network name**: Enter a name for this Wi-Fi connection. This value is the name that users see when they browse the list of available connections on their device.
 - **SSID**: Short for **service set identifier**. This property is the real name of the wireless network that devices connect to. However, users only see the network name you configured when they choose the connection.
 - **Connect automatically**: Choose **Enable** to automatically connect to this network when the device is in range. Choose **Disable** to prevent devices from automatically connecting.
-- **Hidden network**: Choose **Enable** if the SSID of the network isn't broadcasted. Choose **Disable** if the SSID of the Network is broadcasted and visible.
+- **Hidden network**: Choose **Enable** if the SSID of the network isn't broadcasted. Choose **Disable** if the SSID of the network is broadcasted and visible.
 - **Security type**: Select the security protocol to authenticate to the Wi-Fi network. Your options:
 
   - **Open (no authentication)**: Only use this option if the network is unsecured.

--- a/intune/wi-fi-settings-ios.md
+++ b/intune/wi-fi-settings-ios.md
@@ -39,13 +39,13 @@ This article describes these settings.
 
 [Create a device profile](device-profile-create.md).
 
-## Basic profiles
+## Basic profile
 
 - **Wi-Fi type**: Choose **Basic**.
 - **Network name**: Enter a name for this Wi-Fi connection. This value is the name that users see when they browse the list of available connections on their device.
 - **SSID**: Short for **service set identifier**. This property is the real name of the wireless network that devices connect to. However, users only see the network name you configured when they choose the connection.
 - **Connect automatically**: Choose **Enable** to automatically connect to this network when the device is in range. Choose **Disable** to prevent devices from automatically connecting.
-- **Hidden network**: Choose **Enable** to hide this network from the list of available networks on the device. The SSID isn't broadcasted. Choose **Disable** to show this network in the list of available networks on the device.
+- **Hidden network**: Choose **Enable** if the SSID of the network isn't broadcasted. Choose **Disable** if the SSID of the Network is broadcasted and visible.
 - **Security type**: Select the security protocol to authenticate to the Wi-Fi network. Your options:
 
   - **Open (no authentication)**: Only use this option if the network is unsecured.


### PR DESCRIPTION
After testing in an iOS device, I realized that this description was inaccurate. It refers to a feature that Intune doesn't do. This option is only to describe the network better, saying if its SSID is broadcasted or not.