### PR TITLE
Make the requirements for the App Config more clear

### DIFF
--- a/intune/data-transfer-between-apps-manage-ios.md
+++ b/intune/data-transfer-between-apps-manage-ios.md
@@ -55,11 +55,15 @@ Configuring the user UPN setting is **required** for devices that are managed by
 
 2.  Deploy the apps and the email profile that you want managed through Intune or your third-party MDM solution using the following generalized steps. This experience is also covered by *Example 1*.
 
-3.  Deploy the app with the following app configuration settings:
+3.  Deploy the app with the following app configuration settings to the managed device:
 
       **key** = IntuneMAMUPN, **value** = <username@company.com>
 
       Example: [‘IntuneMAMUPN’, ‘jondoe@microsoft.com’]
+      
+       > [!NOTE]
+       > In Intune, the App Configuration policy has to be for enrollment type "Managed Devices".
+       > Addicionally, the App needs to be either installed from the Intune Company Portal if set as available or pushed as required to the device. 
 
 4.  Deploy the **Open in management** policy using Intune or your third-party MDM provider to enrolled devices.
 


### PR DESCRIPTION
Currently, there is a big confusion on the requirements for the App Configuration and 'IntuneMAMUPN' key in iOS.
For the 'IntuneMAMUPN' key to work it needs to be pushed as an App Config for Managed devices, which in turn requires the apps to be considered as "managed" to iOS, so in order to achieve this they need to be installed from either the Intune Company Portal or pushed as required.