### PR TITLE
Correcting size requirement for app size

### DIFF
--- a/intune/apps-win32-app-management.md
+++ b/intune/apps-win32-app-management.md
@@ -29,7 +29,7 @@ Intune standalone will allow greater Win32 app management capabilities. While it
 - Windows 10 client needs to be: 
     - joined to Azure Active Directory (AAD) or Hybrid Azure Active Directory, and
     - enrolled in Intune (MDM-managed)
-- Windows application size is capped at 8 GB per app in the public preview 
+- Windows application size is capped at 2 GB per app in the public preview 
 
 ## Prepare the Win32 app content for upload
 


### PR DESCRIPTION
Source:
(Update October 8 2018: Corrected to state that Windows application size is capped at 2 GB per app in the public preview, not 8 GB as previously stated)
https://techcommunity.microsoft.com/t5/Enterprise-Mobility-Security/Sneak-peek-Public-preview-of-Win32-application-deployment-using/ba-p/264460