### PR TITLE
Update Windows Encryption version

### DIFF
--- a/intune/endpoint-protection-windows-10.md
+++ b/intune/endpoint-protection-windows-10.md
@@ -127,7 +127,7 @@ Supported on the following Windows 10 editions with Microsoft Edge installed:
 
 Supported on the following Windows 10 editions:
 
-- Professional
+- Professional (starting in 1809)
 - Business
 - Enterprise
 - Education


### PR DESCRIPTION
I had a case with a customer that was deploying a Configuration Profile for Windows 10 Pro 1803 devices, and it wasn't successful deployed. The issue was related to the windows version. As this doc. (https://docs.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp)  shows, it is only supported for 1809 version.