### PR TITLE
Windows Server 2019 supported as a ODJ connector

### DIFF
--- a/intune/windows-autopilot-hybrid.md
+++ b/intune/windows-autopilot-hybrid.md
@@ -112,7 +112,7 @@ The organizational unit granted the right to create computers must match:
 
 ## Install the Intune Connector
 
-The Intune Connector for Active Directory needs to be installed on a computer running Windows Server 2016 that has access to the Internet and your Active Directory. To increase scale and availability or to support multiple Active Directory domains, you can install multiple connectors in your environment. We recommend installing the connector on a server that is not running any other Intune connectors.
+The Intune Connector for Active Directory needs to be installed on a computer running Windows Server 2016 (or later) that has access to the Internet and your Active Directory. To increase scale and availability or to support multiple Active Directory domains, you can install multiple connectors in your environment. We recommend installing the connector on a server that is not running any other Intune connectors.
 
 1. Make sure that you have a language pack installed and configured as described in [Intune Connector (Preview) language requirements](https://docs.microsoft.com/windows/deployment/windows-autopilot/intune-connector).
 2. In [Intune](https://aka.ms/intuneportal), choose **Device enrollment** > **Windows enrollment** > **Intune Connector for Active Directory (Preview)** > **Add connector**. 


### PR DESCRIPTION
I'm assuming that Windows Server 2019 is also supported for ODJ connector software. Not just Windows Server 2016.