### PR TITLE
Missing built-in bundle ID

### DIFF
--- a/intune/device-restrictions-ios.md
+++ b/intune/device-restrictions-ios.md
@@ -379,6 +379,7 @@ The following list shows the bundle ID of some common built-in iOS apps. To find
 | com.apple.Keynote           | Keynote      | Apple     |
 | com.apple.mobilemail        | Mail         | Apple     |
 | com.apple.Maps              | Maps         | Apple     |
+| com.apple.measure           | Measure      | Apple     |
 | com.apple.MobileSMS         | Messages     | Apple     |
 | com.apple.Music             | Music        | Apple     |
 | com.apple.news              | News         | Apple     |


### PR DESCRIPTION
missing bundle ID for Measure, com.apple.measure