### PR TITLE
Update app-configuration-policies-managed-app.md

### DIFF
--- a/intune/app-configuration-policies-managed-app.md
+++ b/intune/app-configuration-policies-managed-app.md
@@ -35,6 +35,9 @@ ms.collection: M365-identity-device-management
 
 You can use app configuration policies with managed apps that support the Intune App SDK, even on devices that are not enrolled. 
 
+> [!NOTE]
+> Apps must be targeted with Intune App Protection policy in order to receive App Configuration policies. For more information about creating Intune App Protection policies, see [What are app protection policies?](app-protection-policy.md)
+
 1. Sign into the [Azure portal](https://portal.azure.com).
 2. Choose **All services** > **Intune**. Intune is located in the **Monitoring + Management** section.
 3. Choose the **Client apps** workload.


### PR DESCRIPTION
We're hearing from customers that the prerequisite of having app protection policies targeted to an app before app config policies that effect isn't clear. And we're hearing that this is the doc most customers work off of when setting up their app config policies. Borrowing some text from the Managed Browser/Edge docs to make this clear.