### PR TITLE
Update store-apps-company-portal-app.md

### DIFF
--- a/intune/store-apps-company-portal-app.md
+++ b/intune/store-apps-company-portal-app.md
@@ -50,7 +50,7 @@ To manage devices and install apps, your users can install the Company Portal ap
 3. Select **Get the app** to acquire and add the offline Company Portal app to your inventory.
 4. On the **Company portal** app page, select **Manage**.
 5. For **Platform**, select **Windows 10 all devices**, and then select the appropriate **Minimum version**, **Architecture**, and **Download app metadata** values. 
-6. Select **Download** to save the file to your local machine.
+6. Select **Download** under **Package details** to save the file to your local machine.
 
     ![Windows 10 devices, where architecture equals X86, is selected](./media/Win10CP-all-devices.png)
 


### PR DESCRIPTION
I'm not sure how to modify the pictures, but the ones on line 55 and 62 appear to be incorrect. 
55 shows the download button above the package details, and gives a .json file. 
62 shows the .json file along with the Dependencies folder. 

Unfortunately, Intune does not take a .json file. Instead, if I select the download button under "package details", I get the .appxbundle download, which Intune will take. Thus, both pictures should be changed in my opinion. I've made a text edit on line 53 to help identify the proper download button. Pls let me know if questions.