### PR TITLE
Update device-enrollment-program-enroll-ios.md

### DIFF
--- a/intune/device-enrollment-program-enroll-ios.md
+++ b/intune/device-enrollment-program-enroll-ios.md
@@ -156,6 +156,9 @@ Now that you've installed your token, you can create an enrollment profile for D
 
 6. If you chose **Yes** for **Authenticate with Company Portal instead of Apple Setup Assistant**, you can use a Volume Purchase Program (VPP) token to automatically install the Company Portal on the device. In this case, the user doesn't have to supply an Apple ID. To install the Company Portal with a VPP token, choose a token under **Install Company Portal with VPP**. Don't configure a policy to require the app for users, Intune will automatically install the Company Portal on devices with this enrollment profile applied. Make sure that the token doesn't expire and that you have enough device licenses for the Company Portal app. If the token expires or runs out of licenses, Intune installs the App Store Company Portal instead and prompts for an Apple ID. 
 
+    > [!NOTE]
+    > When Authenticate with Company Portal instead of Apple Setup Assistant is set to Yes, make sure the device enrollment process is performed within the first 24 hours of the company portal being downloaded to the DEP device, otherwise enrollment might fail and a factory reset will be needed to enroll the device.
+    
     ![Screenshot of install company portal with VPP.](./media/device-enrollment-program-enroll-ios/install-cp-with-vpp.png)
 
 7. If you chose **No** for **Authenticate with Company Portal instead of Apple Setup Assistant**, but you also want to use conditional access or deploy company apps on the devices, you must install the Company Portal on the devices. To do so, choose **Yes** for **Install Company Portal**.  If you would like users to receive the Company Portal without having to authenticate into the app store, choose to **Install Company Portal with VPP** and select a VPP token. Make sure that the token doesn't expire and that you have enough device licenses for the Company Portal app to deploy correctly.

--- a/intune/device-enrollment-program-enroll-ios.md
+++ b/intune/device-enrollment-program-enroll-ios.md
@@ -157,7 +157,7 @@ Now that you've installed your token, you can create an enrollment profile for D
 6. If you chose **Yes** for **Authenticate with Company Portal instead of Apple Setup Assistant**, you can use a Volume Purchase Program (VPP) token to automatically install the Company Portal on the device. In this case, the user doesn't have to supply an Apple ID. To install the Company Portal with a VPP token, choose a token under **Install Company Portal with VPP**. Don't configure a policy to require the app for users, Intune will automatically install the Company Portal on devices with this enrollment profile applied. Make sure that the token doesn't expire and that you have enough device licenses for the Company Portal app. If the token expires or runs out of licenses, Intune installs the App Store Company Portal instead and prompts for an Apple ID. 
 
     > [!NOTE]
-    > When Authenticate with Company Portal instead of Apple Setup Assistant is set to Yes, make sure the device enrollment process is performed within the first 24 hours of the company portal being downloaded to the DEP device, otherwise enrollment might fail and a factory reset will be needed to enroll the device.
+    > When **Authenticate with Company Portal instead of Apple Setup Assistant** is set to *Yes*, make sure that the device enrollment process is performed within the first 24 hours of the company portal being downloaded to the DEP device. Otherwise enrollment might fail, and a factory reset will be needed to enroll the device.
     
     ![Screenshot of install company portal with VPP.](./media/device-enrollment-program-enroll-ios/install-cp-with-vpp.png)
 


### PR DESCRIPTION
When the company portal gets downloaded on to the device, there is a session initiated between Intune and Apple (that session has an expiration time), and when the enrollment is not completed by signing in to the company portal with the Intune licensed user (which closes that session) and the session has expired (this is the estimated 24 hour period Although we have seen cases were it worked close to 48 hours), the enrollment information is no longer valid and an the device fails to enroll, and the only solution is to start over by factory resenting the device.