### PR TITLE
Homepage setting clarification

### DIFF
--- a/intune/app-configuration-managed-browser.md
+++ b/intune/app-configuration-managed-browser.md
@@ -219,7 +219,7 @@ Using the procedure to create a Microsoft Edge or Managed Browser app configurat
 
 |                                Key                                |                                                           Value                                                            |
 |-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| <strong>com.microsoft.intune.mam.managedbrowser.homepage</strong> | Specify a valid URL. Incorrect URLs are blocked as a security measure.<br>Example: `<https://www.bing.com>` |
+| <strong>com.microsoft.intune.mam.managedbrowser.homepage</strong> | Specify a valid URL. Incorrect URLs are blocked as a security measure.<br>Example: `https://www.bing.com` |
 
 ## How to configure bookmarks for a protected browser
 


### PR DESCRIPTION
The <> symbols are not necessary when configuring the managed browser homepage setting and have been leading to some user confusion.