### PR TITLE
Requirement needed for AppProxyRedirection

### DIFF
--- a/intune/app-configuration-managed-browser.md
+++ b/intune/app-configuration-managed-browser.md
@@ -186,7 +186,7 @@ Microsoft Edge and the Intune Managed Browser and [Azure AD Application Proxy]( 
 
 - Set up your internal applications through the Azure AD Application Proxy.
     - To configure Application Proxy and publish applications, see the [setup documentation](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy). 
-    - [Users must be assigned](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application that you want redirection to take place for. This must be done even if the application is set to Passthrough mode for Pre-Authentication and if the user assignment requirement has been turned off in the Application Proxy settings.
+    - [Users must be assigned](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application that you want redirection to take place for. This must be done even if the application is set to Passthrough mode for Pre-Authentication and if the user assignment requirement has been turned off in the Application Proxy settings.
 - You must be using minimum version 1.2.0 of the Managed Browser app.
 - Users of the Managed Browser or Microsoft Edge app have an [Intune app protection policy](app-protection-policy.md) assigned to the app.
 

--- a/intune/app-configuration-managed-browser.md
+++ b/intune/app-configuration-managed-browser.md
@@ -186,7 +186,7 @@ Microsoft Edge and the Intune Managed Browser and [Azure AD Application Proxy]( 
 
 - Set up your internal applications through the Azure AD Application Proxy.
     - To configure Application Proxy and publish applications, see the [setup documentation](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy). 
-    - [Users must be assigned](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application that you want redirection to take place for. This must be done even if the application is set to Passthrough mode for Pre-Authentication and if the user assignment requirement has been turned off in the Application Proxy settings.
+    - [Users must be assigned](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application where you want redirection to occur. This must be done even if the application is set to Passthrough mode for Pre-Authentication, and if the user assignment requirement has been turned off in the Application Proxy settings.
 - You must be using minimum version 1.2.0 of the Managed Browser app.
 - Users of the Managed Browser or Microsoft Edge app have an [Intune app protection policy](app-protection-policy.md) assigned to the app.
 

--- a/intune/app-configuration-managed-browser.md
+++ b/intune/app-configuration-managed-browser.md
@@ -186,7 +186,7 @@ Microsoft Edge and the Intune Managed Browser and [Azure AD Application Proxy]( 
 
 - Set up your internal applications through the Azure AD Application Proxy.
     - To configure Application Proxy and publish applications, see the [setup documentation](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy). 
-    - [Users must be assigned](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application where you want redirection to occur. This must be done even if the application is set to Passthrough mode for Pre-Authentication, and if the user assignment requirement has been turned off in the Application Proxy settings.
+    - [Users must be assigned](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application for which the redirection is to occur. This must be done even if the application is set to Passthrough mode for Pre-Authentication, and if the user assignment requirement has been turned off in the Application Proxy settings.
 - You must be using minimum version 1.2.0 of the Managed Browser app.
 - Users of the Managed Browser or Microsoft Edge app have an [Intune app protection policy](app-protection-policy.md) assigned to the app.
 

--- a/intune/app-configuration-managed-browser.md
+++ b/intune/app-configuration-managed-browser.md
@@ -186,6 +186,7 @@ Microsoft Edge and the Intune Managed Browser and [Azure AD Application Proxy]( 
 
 - Set up your internal applications through the Azure AD Application Proxy.
     - To configure Application Proxy and publish applications, see the [setup documentation](https://docs.microsoft.com/azure/active-directory/manage-apps/application-proxy). 
+    - [Users must be assigned](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/application-proxy-add-on-premises-application#add-a-user-for-testing) to the Enterprise Application that you want redirection to take place for. This must be done even if the application is set to Passthrough mode for Pre-Authentication and if the user assignment requirement has been turned off in the Application Proxy settings.
 - You must be using minimum version 1.2.0 of the Managed Browser app.
 - Users of the Managed Browser or Microsoft Edge app have an [Intune app protection policy](app-protection-policy.md) assigned to the app.
 


### PR DESCRIPTION
There is a requirement for the AppProxyRedirection key to work in that users must be assigned to the application in Enterprise applications even though this is not required for sites to work with Passthrough Pre-Authentication, nor is it a requirement for the AzureAD MyApps Browser Extension in order for redirection to take place.

Defining that requirement will assist users attempting to set up this type of redirection for sites that they want to publish to their end users directly to the internet.