### PR TITLE
Call out that Workplace Join is not valid scenario

### DIFF
--- a/intune/intune-management-extension.md
+++ b/intune/intune-management-extension.md
@@ -59,7 +59,7 @@ The Intune management extension has the following prerequisites. Once these are 
   
   - Devices manually enrolled in Intune, which is when:
   
-    - User signs in to the device using a local user account, and then manually joins the device to Azure AD (and auto-enrollment to Intune is enabled in Azure AD).
+    - User signs in to the device using a local user account, manually joins the device to Azure AD (with auto-enrollment to Intune enabled in Azure AD), and then signs into the device using the Azure AD account.
     
     Or
     


### PR DESCRIPTION
I added the change above, but there may be a cleaner way to communicate this. The way the sentence is written it can be confusing since it starts with a Local account and doesn't spell out the finishing steps to performing an Azure AD Join. Also, clicking "Connect" in the settings where manual AAD Joins are made will instead Workplace Join the device (Azure AD Register) and put the device into a scenario that is not valid for IME/Win32 app deployment. There's nothing in the Windows 10 'Access Work or School' settings menu that calls this out, and we're getting support cases where admins are getting (understandably) mixed up.

Another feasible change would be adding an "Excluding" section that calls out Workplace Join as not valid, or adding the following links to accompany the join vs register methods: 

(Azure AD) Join your work device to your organization's network: https://docs.microsoft.com/en-us/azure/active-directory/user-help/user-help-join-device-on-network

(Azure AD) Register personal devices on your organization's network: https://docs.microsoft.com/en-us/azure/active-directory/user-help/user-help-register-device-on-network