### PR TITLE
Update windows-enroll.md

### DIFF
--- a/intune/windows-enroll.md
+++ b/intune/windows-enroll.md
@@ -51,6 +51,10 @@ Two factors determine how you can simplify Windows device enrollment:
 
 Organizations that can use automatic enrollment can also configure [bulk enroll devices](windows-bulk-enroll.md) by using the Windows Configuration Designer app.
 
+## Device enrollment prequisites
+
+Before an administrator can enroll devices to Intune for management, licenses should have already been assigned to the administrator's account. [Read about assigning licenses for device enrollment](licenses-assign.md)
+
 ## Multi-user support
 
 Intune supports multi-management for devices that run the Windows 10 Creator's update and are Azure Active Directory domain-joined. When standard users sign in with their Azure AD credentials, they receive apps and policies assigned to their user name. Users can't currently use the Company Portal for self-service scenarios like installing apps.


### PR DESCRIPTION
This is based on feedback we got from MDATP customers who are trying to enroll devices so that they can deploy baselines and manage onboarding to MDATP. Originally, the believed this was permission error, but we eventually found this to be a licensing issue. We do have great coverage of license assignment as a prerequisite for enrollment, but I think it should be mentioned again here.

From our SMEs: "Since the assignment did not work until I assigned a license – we need to add that clarification in our docs and perhaps link to Intune guidance on assigning a license to the relevant group"

From the customer: "So sick and tired of this broken permissions nonsense in the entire Microsoft cloud. Azure, o365, Intune, ATP, etc all have no useful permissions. I'm logged in with an account that is an o365 global admin, a full Intune admin, and a full Azure admin yet I get messages like contact a global admin. I can't use features that tell me I need to be a global admin....but .... I .... am a global admin everywhere. Can someone please address this permissions nightmare?”