### PR TITLE
Update windows-enroll.md

### DIFF
--- a/intune/windows-enroll.md
+++ b/intune/windows-enroll.md
@@ -57,7 +57,7 @@ Before an administrator can enroll devices to Intune for management, licenses sh
 
 ## Multi-user support
 
-Intune supports multi-management for devices that run the Windows 10 Creator's update and are Azure Active Directory domain-joined. When standard users sign in with their Azure AD credentials, they receive apps and policies assigned to their user name. Users can't currently use the Company Portal for self-service scenarios like installing apps.
+Intune supports multi-management for devices that run the Windows 10 Creator's update and are Azure Active Directory domain-joined. When standard users sign in with their Azure AD credentials, they receive apps and policies assigned to their user name. 
 
 [!INCLUDE [AAD-enrollment](./includes/win10-automatic-enrollment-aad.md)]
 


### PR DESCRIPTION
this limitation was removed in late June
https://docs.microsoft.com/en-us/intune/whats-new#company-portal-app-on-windows-shared-devices-
Company Portal app on Windows shared devices
Users can now access the Company Portal app on Windows shared devices. End users will see a Shared label on the device tile. This applies to the Windows Company Portal app version 10.3.45609.0 and later.