### PR TITLE
Corrected reference to old terminology (Microsoft Passport)

### DIFF
--- a/intune/windows-hello.md
+++ b/intune/windows-hello.md
@@ -124,4 +124,4 @@ Windows Holographic for Business supports the following Windows Hello for Busine
 - Remember PIN history
 
 ## Further information
-For more information about Microsoft Passport, see [the guide](https://technet.microsoft.com/library/mt589441.aspx) in the Windows 10 documentation.
+For more information about Windows Hello for Business, see [the guide](https://technet.microsoft.com/library/mt589441.aspx) in the Windows 10 documentation.


### PR DESCRIPTION
Changing **Microsoft Passport** to **Windows Hello for Business**.