### PR TITLE
Update endpoint-protection-macos.md

### DIFF
--- a/intune/endpoint-protection-macos.md
+++ b/intune/endpoint-protection-macos.md
@@ -86,6 +86,9 @@ Use the firewall to control connections per-application, rather than per-port. U
 ## FileVault  
 For more information about Apple FileVault settings, see [FDEFileVault](https://developer.apple.com/documentation/devicemanagement/fdefilevault) in the Apple developer content. 
 
+> [!IMPORTANT]  
+     > As of macOS 10.15, FileVault configuration requires user approved MDM enrollment. 
+
 - **FileVault**  
   You can *enable* Full Disk Encryption using XTS-AES 128 with FileVault on devices that run macOS 10.13 and later.  
   - **Not configured**  

--- a/intune/endpoint-protection-macos.md
+++ b/intune/endpoint-protection-macos.md
@@ -87,7 +87,7 @@ Use the firewall to control connections per-application, rather than per-port. U
 For more information about Apple FileVault settings, see [FDEFileVault](https://developer.apple.com/documentation/devicemanagement/fdefilevault) in the Apple developer content. 
 
 > [!IMPORTANT]  
-     > As of macOS 10.15, FileVault configuration requires user approved MDM enrollment. 
+> As of macOS 10.15, FileVault configuration requires user approved MDM enrollment. 
 
 - **FileVault**  
   You can *enable* Full Disk Encryption using XTS-AES 128 with FileVault on devices that run macOS 10.13 and later.  


### PR DESCRIPTION
For macOS Catalina and up (10.15+), FileVault only works on devices that have user-approved enrollment, meaning the end user had to physically approve enrollment on their device. These settings won't worn on 10.15+ devices if the user did not manually approve of the MDM enrollment. This should be added as a note at the top because it is important.