### PR TITLE
Update role needed for connector

### DIFF
--- a/intune/exchange-connector-install.md
+++ b/intune/exchange-connector-install.md
@@ -129,6 +129,9 @@ Perform the following steps to install the Intune on-premises Exchange connector
 
 6. In the **Password** field, provide the password for this account to enable Intune to access the Exchange Server.
 
+   > [!NOTE]
+   > For the connection to be successfull the account you use to sign in to the tenant needs to be at least Intune Service Administrator. Without it you will get a failed connection with error: "The remote server returned an error: (400) Bad Request"
+
 7. Choose **Connect**.
 
    > [!NOTE]

--- a/intune/exchange-connector-install.md
+++ b/intune/exchange-connector-install.md
@@ -130,7 +130,7 @@ Perform the following steps to install the Intune on-premises Exchange connector
 6. In the **Password** field, provide the password for this account to enable Intune to access the Exchange Server.
 
    > [!NOTE]
-   > For the connection to be successfull the account you use to sign in to the tenant needs to be at least Intune Service Administrator. Without it you will get a failed connection with error: "The remote server returned an error: (400) Bad Request"
+   > For the connection to be successfull, the account that you use to sign in to the tenant needs to be at least Intune Service Administrator. Without it you will get a failed connection with error: "The remote server returned an error: (400) Bad Request".
 
 7. Choose **Connect**.
 


### PR DESCRIPTION
When the administrator attempts to sign in to the Intune Tenant, the account needs to both have an intune license and be at least an Intune Service Administrator.
If not, the conector will fail with "The remote server returned an error: (400) Bad Request"