### PR TITLE
Fix URL

### DIFF
--- a/intune/certificates-scep-configure.md
+++ b/intune/certificates-scep-configure.md
@@ -358,7 +358,7 @@ To install the Certificate Connector:
 8. Open a command prompt, enter **services.msc**, and then **Enter**. Right-click the **Intune Connector Service** > **Restart**.
 
 
-To validate that the service is running, open a browser, and enter the following URL. It should return a **403** error: `http://<FQDN_of_your_NDES_server>/certsrv/mscep/mscep.dll`  
+To validate that the service is running, open a browser, and enter the following URL. It should return a **403** error: `https://<FQDN_of_your_NDES_server>/certsrv/mscep/mscep.dll`  
 
 > [!NOTE]  
 > The Intune Certificate Connector supports TLS 1.2. If the server that hosts the connector supports TLS 1.2, then TLS 1.2 is used. If the server doesn't support TLS 1.2, then TLS 1.1 is used. Currently, TLS 1.1 is used for authentication between the devices and server.


### PR DESCRIPTION
Validation point of NDES was set with http, however https is required at this point after the connector is installed.