### PR TITLE
Typo correction for authentication methods

### DIFF
--- a/intune/app-modern-authentication-block.md
+++ b/intune/app-modern-authentication-block.md
@@ -32,7 +32,7 @@ ms.collection: M365-identity-device-management
 
 [!INCLUDE [azure_portal](./includes/azure_portal.md)]
 
-App-based Conditional Access with app protection policies rely on applications using [modern authentication](https://support.office.com/article/Using-Office-365-modern-authentication-with-Office-clients-776c0036-66fd-41cb-8928-5495c0f9168a), which is an implementation of OAuth2. Most current Office mobile and desktop applications use modern authentication. However, there are third-party apps and older Office apps that user other authentication methods, like basic authentication, and forms-based authentication.
+App-based Conditional Access with app protection policies rely on applications using [modern authentication](https://support.office.com/article/Using-Office-365-modern-authentication-with-Office-clients-776c0036-66fd-41cb-8928-5495c0f9168a), which is an implementation of OAuth2. Most current Office mobile and desktop applications use modern authentication. However, there are third-party apps and older Office apps that uses other authentication methods, like basic authentication, and forms-based authentication.
 
 ## Block access to apps
 


### PR DESCRIPTION
In the introduction paragraph updated typo for authentication methods, the word should be "uses" instead of "user".