### PR TITLE
Update guided-scenarios-cloud-managed-pc.md

### DIFF
--- a/intune/fundamentals/guided-scenarios-cloud-managed-pc.md
+++ b/intune/fundamentals/guided-scenarios-cloud-managed-pc.md
@@ -29,7 +29,7 @@ If you want to evaluate a cloud-managed modern desktop in your own organization,
 
 ## Prerequisites
 - [Set the MDM authority to Intune](~/fundamentals/mdm-authority-set.md#set-mdm-authority-to-intune) - The mobile device management (MDM) authority setting determines how you manage your devices. As an IT admin, you must set an MDM authority before users can enroll devices for management.
-- M356 E3 minimum (or M365 E5 for best security)
+- Enterprise Mobility + Security E3 minimum (or Enterprise Mobility + Security E5 for best security)
 - Windows 10 1903 device (registered with Windows Autopilot for best end-user experience)
 - Intune administrator permissions required to complete this guided scenario:
   - Device configuration Read, Create, Delete, Assign and Update


### PR DESCRIPTION
I believe Enterprise Mobility + Security E3 should be considered minimum license prerequisite instead of Microsoft 365 E3. Installing the Office 365 ProPlus Suite on a Cloud-managed PC can be done if the Intune Administrator has this license. A Cloud-managed PC doesn't need to be Windows 10 Enterprise either.