### PR TITLE
Dead URL change for Knox Service Plugin Guide docs

### DIFF
--- a/intune/configuration/android-oem-configuration-overview.md
+++ b/intune/configuration/android-oem-configuration-overview.md
@@ -145,7 +145,7 @@ Compared to standard apps, OEMConfig apps expand the managed configurations priv
 
 | OEM | Bundle ID | OEM Documentation (if available) |
 | --- | --- | ---|
-| Samsung | com.samsung.android.knox.kpu | [Knox Service Plugin Admin Guide](https://docs.samsungknox.com/knox-service-plugin/admin-guide/welcome.htm) |
+| Samsung | com.samsung.android.knox.kpu | [Knox Service Plugin Admin Guide](https://docs.samsungknox.com/knox-service-plugin/admin-guide/index.htm) |
 | Zebra Technologies | com.zebra.oemconfig.common | [Zebra OEMConfig overview](http://techdocs.zebra.com/oemconfig ) |
 | Datalogic | com.datalogic.oemconfig | [User Documentation for Datalogic OEMConfig](https://datalogic.github.io/oemconfig/) |
 | Honeywell | com.honeywell.oemconfig |  |


### PR DESCRIPTION
Changed the existing URL which was dead to a better link which takes us to the Samsung Knox Service Plugin Admin Guide
Old Link - https://docs.samsungknox.com/knox-service-plugin/admin-guide/welcome.htm
New link - https://docs.samsungknox.com/knox-service-plugin/admin-guide/index.htm