### PR TITLE
Adding missing setting to iOS SSO app extension

### DIFF
--- a/intune/configuration/ios-device-features-settings.md
+++ b/intune/configuration/ios-device-features-settings.md
@@ -331,6 +331,7 @@ This feature applies to:
 - **Cache name** (Kerberos only): Enter the Generic Security Services (GSS) name of the Kerberos cache. You most likely don't need to set this value.
 - **App bundle IDs** (Kerberos only): **Add** the app bundle identifiers that should use single sign-on on your devices. These apps are granted access to the Kerberos Ticket Granting Ticket, the authentication ticket, and authenticate users to services they’re authorized to access.
 - **Domain realm mapping** (Kerberos only): **Add** the domain DNS suffixes that should map to your realm. Use this setting when the DNS names of the hosts don’t match the realm name. You most likely don't need to create this custom domain-to-realm mapping.
+- **PKINIT certificate** (Kerberos only): **Select** the Public Key Cryptography for Initial Authentication (PKINIT) certificate that can be used to renew the Kerberos credential without user interaction. The certificate should be a PKCS or SCEP certificate that you previously added to Intune.
 
 ## Wallpaper
 


### PR DESCRIPTION
We recently added another setting so need to update the docs to account for the PKINIT certificate