### PR TITLE
Remove incorrect note about app config and APP

### DIFF
--- a/intune/apps/app-configuration-policies-managed-app.md
+++ b/intune/apps/app-configuration-policies-managed-app.md
@@ -35,9 +35,6 @@ ms.collection: M365-identity-device-management
 
 You can use app configuration policies with managed apps that support the Intune App SDK, even on devices that are not enrolled. 
 
-> [!NOTE]
-> Apps must be targeted with Intune App Protection policy in order to receive App Configuration policies. For more information about creating Intune App Protection policies, see [What are app protection policies?](app-protection-policy.md)
-
 1. Sign in to [Intune](https://go.microsoft.com/fwlink/?linkid=2090973).
 3. Choose the **Client apps** workload.
 4. Choose **App configuration policies** in the **Manage** group, and then choose **Add**.


### PR DESCRIPTION
Revert #2439. I did a bit of digging into why the docs say app protection policy is required for app configuration policy. This seems to be an outdated note that only applied to the Managed Browser when it did not have an enrollment flow of its own and relied on auto-enrollment. Whatever the reason, it is incorrect. I tested out signing in to Edge with a user targeted with config policy but with no protection policy and I confirmed that the config policy does get received.