### PR TITLE
Nesting of bullet-points in multi dex docs

### DIFF
--- a/intune/developer/app-wrapper-prepare-android.md
+++ b/intune/developer/app-wrapper-prepare-android.md
@@ -59,8 +59,9 @@ Before running the tool, review [Security considerations for running the App Wra
     > The Intune App Wrapping Tool does not support Google's v2 and upcoming v3 signature schemes for app signing. After you have wrapped the .apk file using the Intune App Wrapping Tool, the recommendation is to use [Google's provided Apksigner tool]( https://developer.android.com/studio/command-line/apksigner). This will ensure that once your app gets to end user devices, it can be launched properly by Android standards. 
 
 - (Optional) Sometimes an app may hit the Dalvik Executable (DEX) size limit due to the Intune MAM SDK classes that are added during wrapping. DEX files are a part of the compilation of an Android app. The Intune App Wrapping Tool automatically handles DEX file overflow during wrapping for apps with a min API level of 21 or higher (as of [v. 1.0.2501.1](https://github.com/msintuneappsdk/intune-app-wrapping-tool-android/releases)). For apps with a min API level of < 21, best practice would be to increase the min API level using the wrapper's `-UseMinAPILevelForNativeMultiDex` flag. For customers unable to increase the app’s minimum API level, the following DEX overflow workarounds are available. In certain organizations, this may require working with whoever compiles the app (ie. the app build team):
-* Use ProGuard to eliminate unused class references from the app’s primary DEX file.
-* For customers using v3.1.0 or higher of the Android Gradle plugin, disable the [D8 dexer](https://android-developers.googleblog.com/2018/04/android-studio-switching-to-d8-dexer.html).  
+
+  - Use ProGuard to eliminate unused class references from the app’s primary DEX file.
+  - For customers using v3.1.0 or higher of the Android Gradle plugin, disable the [D8 dexer](https://android-developers.googleblog.com/2018/04/android-studio-switching-to-d8-dexer.html).  
 
 ## Install the App Wrapping Tool
 


### PR DESCRIPTION
Fix the nesting of the two optional workarounds related to DEX size limitations when wrapping Android Apps.