### PR TITLE
Updating the SendSuccessNotification Method

### DIFF
--- a/intune/protect/scep-libraries-apis.md
+++ b/intune/protect/scep-libraries-apis.md
@@ -204,7 +204,7 @@ Parameters:
 
     - transactionId           The SCEP Transaction Id
     - certificateRequest      DER-encoded PKCS #10 Certificate Request Base64 encoded as a string
-    - certThumprint           Thumbprint of the provisioned certificate
+    - certThumprint           SHA1 hash of the thumbprint of the provisioned certificate
     - certSerialNumber        Serial number of the provisioned certificate
     - certExpirationDate      Expiration date of the provisioned certificate. The date time string should be formatted as web UTC time (YYYY-MM-DDThh:mm:ss.sssTZD) ISO 8601.
     - certIssuingAuthority    Name of the authority that issued the certificate


### PR DESCRIPTION
Indicated that the SendSuccessNotification method should have a SHA1 hash of the thumbprint for certThumbprint.