### PR TITLE
Clarifies Self-Deploying profile limitations

### DIFF
--- a/intune/enrollment/enrollment-autopilot.md
+++ b/intune/enrollment/enrollment-autopilot.md
@@ -107,6 +107,9 @@ Autopilot deployment profiles are used to configure the Autopilot devices. You c
 
     ![Screenshot of OOBE page](./media/enrollment-autopilot/create-profile-outofbox.png)
 
+> [!NOTE]
+> Self-deploying profiles currently don't support setting "Join to AzureAD as", "Microsoft Software License Terms", "Privacy Settings", "Hide Change Account Options", or "User Account Type"
+
 6. In the **Join to Azure AD as** box, choose **Azure AD joined**.
 7. Configure the following options:
     - **End-user license agreement (EULA)**: (Windows 10, version 1709 or later) Choose if you want to show the EULA to users.

--- a/intune/enrollment/enrollment-autopilot.md
+++ b/intune/enrollment/enrollment-autopilot.md
@@ -107,8 +107,7 @@ Autopilot deployment profiles are used to configure the Autopilot devices. You c
 
     ![Screenshot of OOBE page](./media/enrollment-autopilot/create-profile-outofbox.png)
 
-> [!NOTE]
-> Self-deploying profiles currently don't support setting "Join to AzureAD as", "Microsoft Software License Terms", "Privacy Settings", "Hide Change Account Options", or "User Account Type"
+Greyed-out items are not currently supported by the chosen Deployment mode.
 
 6. In the **Join to Azure AD as** box, choose **Azure AD joined**.
 7. Configure the following options:

--- a/intune/enrollment/enrollment-autopilot.md
+++ b/intune/enrollment/enrollment-autopilot.md
@@ -107,7 +107,8 @@ Autopilot deployment profiles are used to configure the Autopilot devices. You c
 
     ![Screenshot of OOBE page](./media/enrollment-autopilot/create-profile-outofbox.png)
 
-Greyed-out items are not currently supported by the chosen Deployment mode.
+   > [!NOTE]
+   > Options that appear dimmed or shaded are currently not supported by the selected deployment mode.
 
 6. In the **Join to Azure AD as** box, choose **Azure AD joined**.
 7. Configure the following options:


### PR DESCRIPTION
Clarifies that Self-Deploying settings for "Join to AzureAD as", "Microsoft Software License Terms", "Privacy Settings", "Hide Change Account Options", or "User Account Type" cannot be set and that this is the current expected behavior for Self-deploying.

This is also supported by the following:

- The settings listed in this article: https://oofhours.com/2019/10/01/inside-windows-autopilot-self-deploying-mode/
- This comment and response: https://www.petervanderwoude.nl/post/windows-autopilot-self-deploying-mode/#comment-83397

It can also be verified by simply going through the flow of creating a self-deploying profile.