### PR TITLE
Fixed Office C2R on s-Mode app applicability table

### DIFF
--- a/intune/apps/apps-windows-10-app-deploy.md
+++ b/intune/apps/apps-windows-10-app-deploy.md
@@ -52,7 +52,7 @@ Specific app types are supported based on the version of Windows 10 that your us
 |----------------|------|-----|----------|------------|-----------|--------|-----------|------------|------|--------|
 |  .MSI | No | Yes | Yes | Yes | Yes | No | No | No | No | No |
 | .IntuneWin | No | Yes | Yes | Yes | Yes | 19H2+ | No | No | No | No |
-| Office C2R | No | Yes | Yes | Yes | Yes | No | No | No | No | No |
+| Office C2R | No | Yes | Yes | Yes | Yes | RS4+ | No | No | No | No |
 | LOB: APPX/MSIX | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | MSFB Offline | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | MSFB Online | Yes | Yes | Yes | Yes | Yes | Yes | RS4+ | Yes | Yes | Yes |


### PR DESCRIPTION
Office C2R is supported on devices in S-Mode running RS4 and up. RS3 doesn't support S-mode, but has an S SKU, which doesn't support Office C2R.

Learn more here:
https://docs.microsoft.com/en-us/windows/deployment/s-mode